### PR TITLE
Made /users endpoint reachable via the web interface

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,8 +20,8 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.static('client/build'));
 
-app.use('/', indexRouter);
-app.use('/users', usersRouter);
+app.use('/api/users', usersRouter);
+app.use('/*', indexRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {


### PR DESCRIPTION
It seems that the `/*` path of the indexRouter was overriding the `/users` endpoint. Declaring the index endpoint below the `/users` endpoint seems to solve the problem.

fixes #15 